### PR TITLE
Don't pin to node v12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
 requirements:
   host:
   run:
-    - nodejs =>12
+    - nodejs >=12
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,14 +14,14 @@ source:
     code-server
 
 build:
-  number: 0
+  number: 1
   binary_relocation: False  # [osx]
   skip: true  # [win]
 
 requirements:
   host:
   run:
-    - nodejs 12.*
+    - nodejs =>12
 
 test:
   commands:


### PR DESCRIPTION
The [code-server readme](https://github.com/cdr/code-server) says "at least node v12".

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
