### PR TITLE
Pin nodejs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,14 +13,14 @@ source:
   folder: code-server
 
 build:
-  number: 0
+  number: 1
   binary_relocation: false  # [osx]
   skip: true  # [win]
 
 requirements:
   host:
   run:
-    - nodejs 12.*
+    - nodejs 14.*
 
 test:
   commands:


### PR DESCRIPTION
Closes #20. Pinning nodejs at 14 because that's used to build the code-server binary.

Still have to verify that this works on osx.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.