### PR TITLE
Pin nodejs to v12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,14 +13,14 @@ source:
   folder: code-server
 
 build:
-  number: 0
+  number: 1
   binary_relocation: false  # [osx]
   skip: true  # [win]
 
 requirements:
   host:
   run:
-    - nodejs 14.*
+    - nodejs 12.*
 
 test:
   commands:


### PR DESCRIPTION
As the last item in the release note (https://github.com/cdr/code-server/releases/tag/v3.5.0)
states, code-server pins nodejs the same version used by VS Code.
This prevents problems like #20.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
