### PR TITLE
Make code-server wrapper independent of CONDA_PREFIX

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,14 +8,33 @@ mkdir -p ${PREFIX}/bin
 mkdir -p ${PREFIX}/share/code-server/extensions
 cat <<'EOF' >${PREFIX}/bin/code-server
 #!/bin/bash
+
+PREFIX_DIR=$(dirname ${BASH_SOURCE}})
+
+# Make PREDIX_DIR absolute
+if [[ $(uname) == 'Linux' ]]; then
+  PREFIX_DIR=$(readlink -f ${PREFIX_DIR})
+else
+  pushd ${PREFIX_DIR}
+  PREFIX_DIR=$(pwd -P)
+  popd
+fi
+
+# Go one level up
+PREFIX_DIR=$(dirname ${PREFIX_DIR})
+
 EXTENSIONS_DIR_ARG="--extensions-dir"
-EXTENSIONS_DIR_VAL="${CONDA_PREFIX}/share/code-server/extensions"
+EXTENSIONS_DIR_VAL="${PREFIX_DIR}/share/code-server/extensions"
 if [[ "$*" != *"${EXTENSIONS_DIR_ARG}"* ]]; then
     set -- "$*" "${EXTENSIONS_DIR_ARG} ${EXTENSIONS_DIR_VAL}"
 fi
-node ${CONDA_PREFIX}/share/code-server/out/node/entry.js $*
+
+node ${PREFIX_DIR}/share/code-server/out/node/entry.js $*
 EOF
 chmod +x ${PREFIX}/bin/code-server
+
+# Directly check whether the code-server call also works inside of conda-build
+code-server --help
 
 # Remove unnecessary resources
 find ${PREFIX}/share/code-server -name '*.map' -delete

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-set -euo pipefail
+set -exuo pipefail
 
-mkdir $PREFIX/share
+mkdir -p $PREFIX/share
 cp -r code-server $PREFIX/share/
 mkdir -p ${PREFIX}/bin
 mkdir -p ${PREFIX}/share/code-server/extensions

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   folder: code-server
 
 build:
-  number: 2
+  number: 3
   binary_relocation: false  # [osx]
   skip: true  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ build:
 
 requirements:
   host:
+    - nodejs 12.*
   run:
     - nodejs 12.*
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
